### PR TITLE
test: enhance group message testing with integration tests

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -533,6 +533,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		const results = await Promise.allSettled(encryptionPromises)
 
 		const nodes: BinaryNode[] = []
+		const errors: Error[] = []
 		results.forEach((result, i) => {
 			if (result.status === 'fulfilled') {
 				// If the promise was fulfilled, add the resulting node to our list.
@@ -544,8 +545,15 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 				// We get the failed ID from the original list using the index.
 				const failedId = (patchedMessages as any)[i]?.recipientJid
 				logger.warn({ id: failedId, err: result.reason?.message }, 'Skipping participant due to encryption failure')
+				errors.push(result.reason as Error)
 			}
 		})
+
+		// If no participants were successfully encrypted and this is not a group context, throw the first error
+		if (nodes.length === 0 && errors.length > 0 && recipientJids.length === 1) {
+			throw errors[0]
+		}
+
 		return { nodes, shouldIncludeDeviceIdentity }
 	}
 
@@ -879,6 +887,12 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 						content: participants
 					})
 				}
+			}
+
+			// If no participants could be encrypted for groups/status, don't send the message
+			if ((isGroup || isStatus) && participants.length === 0) {
+				logger.warn({ jid }, 'No participants could be encrypted, skipping message send')
+				return msgId // Still return the message ID as if sent, but don't actually send
 			}
 
 			const stanza: BinaryNode = {

--- a/src/__tests__/TestUtils/mock-socket-dependencies.ts
+++ b/src/__tests__/TestUtils/mock-socket-dependencies.ts
@@ -1,0 +1,273 @@
+import { jest } from '@jest/globals'
+import { proto } from '../..'
+import { DEFAULT_CONNECTION_CONFIG } from '../../Defaults'
+import type { AuthenticationState, SignalDataSet, SignalDataTypeMap } from '../../Types'
+import type { SignalRepositoryWithLIDStore } from '../../Types/Signal'
+import type { SocketConfig } from '../../Types/Socket'
+import type { ILogger } from '../../Utils/logger'
+import { jidNormalizedUser } from '../../WABinary'
+
+/**
+ * Shared constants for tests to ensure consistency across all test suites.
+ */
+export const TEST_JIDS = {
+	group: '123456789-123345@g.us',
+	goodParticipant1: '1111111111@s.whatsapp.net',
+	badParticipant: '2222222222@s.whatsapp.net',
+	goodParticipant2: '3333333333@s.whatsapp.net',
+	me: '9999999999@s.whatsapp.net'
+} as const
+
+/**
+ * All participants for the mock group metadata.
+ */
+const ALL_PARTICIPANTS = [
+	TEST_JIDS.goodParticipant1,
+	TEST_JIDS.badParticipant,
+	TEST_JIDS.goodParticipant2,
+	TEST_JIDS.me
+]
+
+/**
+ * Creates a mock logger with all required methods.
+ * Returns a logger that can be used with jest.fn() spies.
+ */
+export const createMockLogger = () => {
+	const logger: any = {
+		child: jest.fn(),
+		trace: jest.fn(),
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn()
+	}
+	logger.child.mockReturnValue(logger)
+	return logger as ILogger & {
+		child: jest.Mock
+		trace: jest.Mock
+		debug: jest.Mock
+		info: jest.Mock
+		warn: jest.Mock
+		error: jest.Mock
+	}
+}
+
+/**
+ * Creates a mock AuthenticationState for testing.
+ */
+export const createMockAuthState = (meJid: string = TEST_JIDS.me): AuthenticationState => {
+	const keys = {
+		get: async <T extends keyof SignalDataTypeMap>(
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			_type: T,
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			_ids: string[]
+		): Promise<Record<string, SignalDataTypeMap[T]>> => ({}),
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		set: async (_data: SignalDataSet) => {},
+		clear: async () => {},
+		transaction: async <T>(exec: () => Promise<T>) => exec(),
+		isInTransaction: () => false
+	}
+
+	return {
+		creds: {
+			me: { id: meJid, name: 'Me' }
+		} as any,
+		keys: keys as unknown as AuthenticationState['keys']
+	}
+}
+
+/**
+ * Creates a mock SignalRepository with configurable encryption failure behavior.
+ * @param failingParticipantJid - The JID that should fail encryption attempts.
+ */
+export const createMockSignalRepository = (failingParticipantJid: string): SignalRepositoryWithLIDStore => {
+	const badNormalized = jidNormalizedUser(failingParticipantJid)
+
+	return {
+		encryptMessage: jest.fn(async ({ jid }: { jid: string }) => {
+			const normalized = jidNormalizedUser(jid)
+			if (normalized === badNormalized) {
+				throw new Error(`Simulated Session Error for ${jid}`)
+			}
+
+			return {
+				type: 'pkmsg' as const,
+				ciphertext: Buffer.from('encrypted-message')
+			}
+		}),
+		encryptGroupMessage: jest.fn(async () => ({
+			senderKeyDistributionMessage: Buffer.from('skdm'),
+			ciphertext: Buffer.from('group-encrypted')
+		})),
+		processSenderKeyDistributionMessage: jest.fn(async () => {}),
+		deleteSession: jest.fn(async () => {}),
+		validateSession: jest.fn(async () => ({ exists: true })),
+		jidToSignalProtocolAddress: (jid: string) => jid,
+		lidMapping: {
+			getLIDsForPNs: async () => [],
+			storeLIDPNMappings: async () => {}
+		}
+	} as unknown as SignalRepositoryWithLIDStore
+}
+
+/**
+ * Creates a mock user devices cache.
+ */
+export const createMockUserDevicesCache = () => {
+	const buildEntry = (user: string) => [{ user, device: 0 }]
+	return {
+		get: jest.fn(async (user: string) => buildEntry(user)),
+		set: jest.fn(),
+		del: jest.fn(),
+		flushAll: jest.fn(),
+		mget: jest.fn(async (users: string[]) => Object.fromEntries(users.map(user => [user, buildEntry(user)]))),
+		mset: jest.fn()
+	}
+}
+
+/**
+ * Creates mock group metadata for testing.
+ */
+export const createMockGroupMetadata = (groupJid: string = TEST_JIDS.group) => ({
+	id: groupJid,
+	subject: 'Test Group',
+	owner: undefined,
+	participants: ALL_PARTICIPANTS.map(id => ({ id, admin: null }))
+})
+
+/**
+ * Options for creating a test socket environment.
+ */
+export interface CreateTestSocketOptions {
+	/** The JID of the participant whose encryption should fail. Defaults to TEST_JIDS.badParticipant */
+	failingParticipantJid?: string
+	/** The JID of the current user. Defaults to TEST_JIDS.me */
+	meJid?: string
+	/** Custom group metadata. If not provided, uses default mock metadata */
+	groupMetadata?: ReturnType<typeof createMockGroupMetadata>
+	/** Custom signal repository. If not provided, uses default mock with failingParticipantJid logic */
+	signalRepository?: SignalRepositoryWithLIDStore
+}
+
+/**
+ * Return type for createTestSocketAndDependencies function.
+ * Provides type-safe access to all test fixtures and mocks.
+ */
+export interface TestSocketEnvironment {
+	/** The socket instance with message functionality ready for testing */
+	socket: ReturnType<(typeof import('../../Socket/messages-send.js'))['makeMessagesSocket']>
+	/** Mock logger with jest spies for all logging methods */
+	logger: ReturnType<typeof createMockLogger>
+	/** Mock authentication state */
+	authState: AuthenticationState
+	/** Mock signal repository with configurable failure behavior */
+	signalRepository: SignalRepositoryWithLIDStore
+	/** Jest mock for the sendNode function */
+	sendNodeMock: jest.Mock
+	/** The base mock socket object passed to makeMessagesSocket */
+	mockBaseSocket: any
+	/** Mock group metadata used in tests */
+	fakeMetadata: ReturnType<typeof createMockGroupMetadata>
+	/** Socket configuration used to create the socket */
+	config: SocketConfig
+}
+
+export const createTestSocketAndDependencies = (
+	mockNewsletterSocket: jest.Mock,
+	makeMessagesSocket: (typeof import('../../Socket/messages-send.js'))['makeMessagesSocket'],
+	options: CreateTestSocketOptions = {}
+): TestSocketEnvironment => {
+	const {
+		failingParticipantJid = TEST_JIDS.badParticipant,
+		meJid = TEST_JIDS.me,
+		groupMetadata,
+		signalRepository: customSignalRepository
+	} = options
+
+	// 1. Create a mock logger with spies
+	const logger = createMockLogger()
+
+	// 2. Create mock auth state
+	const authState = createMockAuthState(meJid)
+
+	// 3. Create the mock signal repository with the failure logic or use custom
+	const signalRepository = customSignalRepository || createMockSignalRepository(failingParticipantJid)
+
+	// 4. Create the mock for the final `sendNode` call
+	const sendNodeMock = jest.fn()
+
+	// 5. Create mock group metadata
+	const fakeMetadata = groupMetadata || createMockGroupMetadata()
+
+	// 6. Assemble the mock base socket that `makeMessagesSocket` will wrap
+	const mockBaseSocket: any = {
+		ev: { emit: jest.fn(), on: jest.fn(), off: jest.fn() },
+		authState,
+		processingMutex: { mutex: (task: () => Promise<any>) => task() },
+		signalRepository,
+		upsertMessage: jest.fn(),
+		query: async () => ({}),
+		fetchPrivacySettings: async () => undefined,
+		sendNode: sendNodeMock,
+		groupMetadata: async () => fakeMetadata,
+		groupToggleEphemeral: async () => undefined,
+		profilePictureUrl: async () => undefined,
+		logger
+	}
+
+	mockNewsletterSocket.mockReturnValue(mockBaseSocket)
+
+	// 7. Create the socket configuration
+	const config: SocketConfig = {
+		...DEFAULT_CONNECTION_CONFIG,
+		auth: authState,
+		logger,
+		patchMessageBeforeSending: (msg: proto.IMessage) => msg,
+		cachedGroupMetadata: async (jid: string) => (jid === TEST_JIDS.group ? (fakeMetadata as any) : undefined),
+		getMessage: async () => undefined,
+		userDevicesCache: createMockUserDevicesCache() as any,
+		makeSignalRepository: () => signalRepository
+	}
+
+	// 8. Create the actual `makeMessagesSocket` instance using all our mocks
+	const socket = makeMessagesSocket(config)
+
+	// 9. Return everything the test needs
+	return {
+		socket,
+		logger,
+		authState,
+		signalRepository,
+		sendNodeMock,
+		mockBaseSocket,
+		fakeMetadata,
+		config
+	}
+}
+
+/**
+ * Sets up the newsletter socket mock for testing.
+ * Call this in beforeAll of your test file.
+ */
+export const setupNewsletterMock = () => {
+	const mockNewsletterSocket = jest.fn()
+
+	// Mock the newsletter module
+	jest.unstable_mockModule('../../Socket/newsletter.js', () => ({
+		__esModule: true,
+		makeNewsletterSocket: mockNewsletterSocket
+	}))
+
+	return mockNewsletterSocket
+}
+
+/**
+ * Gets the makeMessagesSocket function after newsletter mock is set up.
+ * Call this in beforeAll after setupNewsletterMock.
+ */
+export const getMakeMessagesSocket = async () => {
+	const { makeMessagesSocket } = await import('../../Socket/messages-send.js')
+	return makeMessagesSocket
+}

--- a/src/__tests__/integration/group-message-business-logic.test.ts
+++ b/src/__tests__/integration/group-message-business-logic.test.ts
@@ -1,0 +1,256 @@
+import { jest } from '@jest/globals'
+import type { WAMessageKey } from '../../Types'
+import type { BinaryNode } from '../../WABinary'
+import { jidNormalizedUser } from '../../WABinary'
+import {
+	createMockSignalRepository,
+	createTestSocketAndDependencies,
+	getMakeMessagesSocket,
+	setupNewsletterMock,
+	TEST_JIDS
+} from '../TestUtils/mock-socket-dependencies'
+
+let mockNewsletterSocket: jest.Mock
+let makeMessagesSocket: (typeof import('../../Socket/messages-send.js'))['makeMessagesSocket']
+
+beforeAll(async () => {
+	jest.resetModules()
+	mockNewsletterSocket = setupNewsletterMock()
+	makeMessagesSocket = await getMakeMessagesSocket()
+})
+
+afterEach(() => {
+	jest.clearAllMocks()
+})
+
+describe('Business logic: group sendMessage resilience', () => {
+	test('should successfully send a message to valid group participants, skipping the one that fails', async () => {
+		// Use the factory to set up the environment
+		const { socket, logger, sendNodeMock } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			failingParticipantJid: TEST_JIDS.badParticipant
+		})
+
+		// --- EXECUTION ---
+		// Call the public API - sock.sendMessage
+		const result = await socket.sendMessage(TEST_JIDS.group, { text: 'Hello, resilient group!' })
+
+		// --- VERIFICATION ---
+		// 1. Verify the message was created successfully
+		expect(result).toBeDefined()
+		expect(result!.key).toBeDefined()
+		expect(result!.key.remoteJid).toBe(TEST_JIDS.group)
+
+		// 2. Verify that sendNode was called (message was prepared for sending)
+		expect(sendNodeMock).toHaveBeenCalledTimes(1)
+
+		// 3. Inspect the payload that would be sent over the wire
+		const sentNode = sendNodeMock.mock.calls[0]?.[0] as BinaryNode | undefined
+		const participantsNode = Array.isArray(sentNode?.content)
+			? sentNode?.content.find((node: BinaryNode) => node.tag === 'participants')
+			: undefined
+		const recipientJids = Array.isArray(participantsNode?.content)
+			? participantsNode.content.map(node => (node.attrs as any).jid)
+			: []
+
+		// 4. Assert the business logic: message prepared for good participants
+		expect(recipientJids).toEqual(
+			expect.arrayContaining([
+				jidNormalizedUser(TEST_JIDS.goodParticipant1),
+				jidNormalizedUser(TEST_JIDS.goodParticipant2)
+			])
+		)
+
+		// 5. Assert the core of the fix: bad participant excluded
+		expect(recipientJids).not.toContain(jidNormalizedUser(TEST_JIDS.badParticipant))
+
+		// 6. Assert failure was logged for debugging
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ id: expect.stringContaining(TEST_JIDS.badParticipant) }),
+			'Skipping participant due to encryption failure'
+		)
+	})
+
+	test('should handle multiple participants with mixed encryption states', async () => {
+		// Use the factory to set up the environment
+		const { socket, logger, sendNodeMock } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			failingParticipantJid: TEST_JIDS.badParticipant
+		})
+
+		// --- EXECUTION ---
+		// With the fix applied, this should succeed even with a failing participant
+		const result = await socket.sendMessage(TEST_JIDS.group, { text: 'Mixed encryption states handled' })
+
+		// --- VERIFICATION ---
+		expect(result).toBeDefined()
+		expect(sendNodeMock).toHaveBeenCalledTimes(1)
+
+		// Verify warning was logged for the failed participant
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ id: expect.stringContaining(TEST_JIDS.badParticipant) }),
+			'Skipping participant due to encryption failure'
+		)
+	})
+
+	test('should include the "edit" attribute when sending an edited message', async () => {
+		// We don't need any failing participants for this test.
+		const { socket, sendNodeMock } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			failingParticipantJid: 'no-one-will-fail@s.whatsapp.net'
+		})
+
+		const originalMessageKey: WAMessageKey = {
+			remoteJid: TEST_JIDS.group,
+			id: 'ORIGINAL_MESSAGE_ID',
+			fromMe: true
+		}
+
+		// --- EXECUTION ---
+		await socket.sendMessage(TEST_JIDS.group, {
+			text: 'This is an edited message',
+			edit: originalMessageKey
+		})
+
+		// --- VERIFICATION ---
+		expect(sendNodeMock).toHaveBeenCalledTimes(1)
+
+		const sentNode = sendNodeMock.mock.calls[0]?.[0] as BinaryNode | undefined
+		expect(sentNode).toBeDefined()
+
+		// Assert that the top-level message node has the 'edit' attribute set to '1'
+		expect(sentNode!.tag).toBe('message')
+		expect(sentNode!.attrs.edit).toBe('1')
+	})
+
+	test('should send a senderKeyDistributionMessage to participants without a known key', async () => {
+		const { socket, sendNodeMock, signalRepository, authState } = createTestSocketAndDependencies(
+			mockNewsletterSocket,
+			makeMessagesSocket,
+			{
+				failingParticipantJid: 'no-one-will-fail@s.whatsapp.net'
+			}
+		)
+
+		// 1. Setup: Mock the 'sender-key-memory' to simulate not having a key for one participant.
+		// Let's pretend we don't have a key for goodParticipant2.
+		jest.spyOn(authState.keys, 'get').mockImplementation(async (type, ids) => {
+			if (type === 'sender-key-memory' && ids.includes(TEST_JIDS.group)) {
+				return {
+					[TEST_JIDS.group]: {
+						// We have a key for goodParticipant1, but not for goodParticipant2
+						[jidNormalizedUser(TEST_JIDS.goodParticipant1)]: true
+					}
+				} as Record<string, Record<string, boolean>>
+			}
+
+			return {}
+		})
+
+		// 2. Act: Send a message
+		await socket.sendMessage(TEST_JIDS.group, { text: 'Welcome new member!' })
+
+		// 3. Assert
+		expect(sendNodeMock).toHaveBeenCalledTimes(1)
+		const sentNode = sendNodeMock.mock.calls[0]?.[0] as BinaryNode
+		expect(sentNode).toBeDefined()
+		expect(Array.isArray(sentNode.content)).toBe(true)
+
+		const participantsNode = (sentNode.content as BinaryNode[]).find(c => c.tag === 'participants')
+		expect(participantsNode).toBeDefined()
+		expect(Array.isArray(participantsNode!.content)).toBe(true)
+
+		// Find the participant node for the "new" member (goodParticipant2)
+		const newParticipantNode = (participantsNode!.content as BinaryNode[]).find(
+			p => p.attrs.jid === jidNormalizedUser(TEST_JIDS.goodParticipant2)
+		)
+
+		expect(newParticipantNode).toBeDefined()
+
+		// It should contain an encrypted sender key message just for them.
+		// We expect two calls to encryptMessage: one for the sender key, one for the group message.
+		// A simpler assertion is to check if the spy was called for the new participant.
+		expect(signalRepository.encryptMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ jid: jidNormalizedUser(TEST_JIDS.goodParticipant2) })
+		)
+	})
+})
+
+describe('Business Logic: 1-on-1 Chat Resilience', () => {
+	test('should reject the sendMessage promise if encryption fails for a single recipient', async () => {
+		const { socket, logger, sendNodeMock } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			// We'll use one of the "good" participants as our target, but make them fail
+			failingParticipantJid: TEST_JIDS.goodParticipant1
+		})
+
+		// --- EXECUTION & VERIFICATION ---
+		await expect(socket.sendMessage(TEST_JIDS.goodParticipant1, { text: 'This will fail' })).rejects.toThrow(
+			`Simulated Session Error for ${TEST_JIDS.goodParticipant1}`
+		)
+
+		expect(sendNodeMock).not.toHaveBeenCalled()
+
+		// We expect a warning to be logged for the failed encryption
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: TEST_JIDS.goodParticipant1,
+				err: 'Simulated Session Error for ' + TEST_JIDS.goodParticipant1
+			}),
+			'Skipping participant due to encryption failure'
+		)
+	})
+})
+
+describe('Business Logic: Group Edge Cases', () => {
+	test('should handle case when participants fail encryption', async () => {
+		// Create a socket where only goodParticipant1 will fail
+		const { socket, logger, sendNodeMock } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			failingParticipantJid: TEST_JIDS.goodParticipant1
+		})
+
+		// --- EXECUTION ---
+		await socket.sendMessage(TEST_JIDS.group, { text: 'Message with some failures' })
+
+		// --- VERIFICATION ---
+		expect(sendNodeMock).toHaveBeenCalledTimes(1)
+
+		const sentNode = sendNodeMock.mock.calls[0]?.[0] as BinaryNode | undefined
+		expect(sentNode).toBeDefined()
+
+		const participantsNode = Array.isArray(sentNode!.content)
+			? sentNode!.content.find((node: BinaryNode) => node.tag === 'participants')
+			: undefined
+
+		const recipientJids = Array.isArray(participantsNode?.content)
+			? participantsNode.content.map(node => (node.attrs as any).jid)
+			: []
+
+		// Should include goodParticipant2, badParticipant (not failing in this test), and me, but not goodParticipant1 (failing)
+		expect(recipientJids).toContain(jidNormalizedUser(TEST_JIDS.goodParticipant2))
+		expect(recipientJids).toContain(jidNormalizedUser(TEST_JIDS.badParticipant)) // badParticipant works in this test
+		expect(recipientJids).not.toContain(jidNormalizedUser(TEST_JIDS.goodParticipant1)) // goodParticipant1 fails
+
+		// Should log warnings for the failed participant
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ id: expect.stringContaining(TEST_JIDS.goodParticipant1) }),
+			'Skipping participant due to encryption failure'
+		)
+	})
+
+	test('should not send a message if all participants fail encryption', async () => {
+		// Setup a signal repo that always fails
+		const alwaysFailingRepo = createMockSignalRepository('some-jid') // An unused JID
+		;(alwaysFailingRepo.encryptMessage as any).mockImplementation(() => {
+			throw new Error('Universal Failure')
+		})
+
+		const { socket, sendNodeMock, logger } = createTestSocketAndDependencies(mockNewsletterSocket, makeMessagesSocket, {
+			signalRepository: alwaysFailingRepo
+		})
+
+		// Act
+		await socket.sendMessage(TEST_JIDS.group, { text: 'Message to no one' })
+
+		// Assert
+		expect(sendNodeMock).not.toHaveBeenCalled()
+		// Verify that warnings were logged for failed encryptions
+		expect(logger.warn).toHaveBeenCalled()
+	})
+})

--- a/src/__tests__/integration/group-message-failure.test.ts
+++ b/src/__tests__/integration/group-message-failure.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals'
+import { proto } from '../..'
+import { jidNormalizedUser } from '../../WABinary'
+import {
+	createTestSocketAndDependencies,
+	getMakeMessagesSocket,
+	setupNewsletterMock,
+	TEST_JIDS
+} from '../TestUtils/mock-socket-dependencies'
+
+let mockNewsletterSocket: jest.Mock
+let makeMessagesSocket: (typeof import('../../Socket/messages-send.js'))['makeMessagesSocket']
+
+beforeAll(async () => {
+	jest.resetModules()
+	mockNewsletterSocket = setupNewsletterMock()
+	makeMessagesSocket = await getMakeMessagesSocket()
+})
+
+afterEach(() => {
+	jest.clearAllMocks()
+})
+
+describe('createParticipantNodes fault tolerance', () => {
+	test('skips failing participant and continues encrypting others', async () => {
+		// Use the factory to set up the environment
+		const { socket, logger, signalRepository } = createTestSocketAndDependencies(
+			mockNewsletterSocket,
+			makeMessagesSocket,
+			{ failingParticipantJid: TEST_JIDS.badParticipant }
+		)
+
+		const { createParticipantNodes } = socket
+
+		// Define the recipients for this test (excluding "me" since we're testing participant nodes)
+		const recipients = [TEST_JIDS.goodParticipant1, TEST_JIDS.badParticipant, TEST_JIDS.goodParticipant2]
+
+		const message = proto.Message.fromObject({ conversation: 'group test' })
+
+		// --- EXECUTION ---
+		// Call the internal function directly
+		const result = await createParticipantNodes(recipients, message)
+
+		// --- VERIFICATION ---
+		// 1. Verify that an encryption attempt was made for everyone
+		expect(signalRepository.encryptMessage).toHaveBeenCalledTimes(recipients.length)
+
+		// 2. Check the direct output of the function - bad participant should be excluded
+		const nodeJids = result.nodes.map((node: any) => node.attrs.jid)
+
+		expect(nodeJids).toEqual(
+			expect.arrayContaining([
+				jidNormalizedUser(TEST_JIDS.goodParticipant1),
+				jidNormalizedUser(TEST_JIDS.goodParticipant2)
+			])
+		)
+		expect(nodeJids).not.toContain(jidNormalizedUser(TEST_JIDS.badParticipant))
+
+		// 3. Verify device identity flag
+		expect(result.shouldIncludeDeviceIdentity).toBe(true)
+
+		// 4. Confirm the failure was logged
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({ id: expect.stringContaining(TEST_JIDS.badParticipant) }),
+			'Skipping participant due to encryption failure'
+		)
+	})
+})


### PR DESCRIPTION
**Key Scenarios Covered:**

*   **Business Logic:** Verifies that `sendMessage` to a group succeeds even if some participants fail encryption, sending only to the valid ones.
*   **Edge Case (1-on-1):** Confirms that `sendMessage` correctly throws an error if a 1-on-1 chat fails encryption.
*   **Edge Case (Group):** Ensures no message is sent if *all* participants in a group fail encryption.
*   **Sender Key Distribution:** Validates that a `senderKeyDistributionMessage` is correctly generated for new participants who don't have an established session.

These tests confirm that the library's behavior aligns with the expected business logic of the WhatsApp Web API, making it more robust and preventing crashes from single-participant failures.

A big thank you to @AstroX11 <3 for the fix!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved group/status message resilience: skip unreachable recipients and continue for others; if none are reachable, do not send but return a message ID.
  - For 1:1 messages, encryption failure now surfaces an error.
  - Added clearer warnings when participants are skipped.

- Tests
  - Added integration tests covering group and 1:1 messaging, mixed encryption outcomes, key distribution, and edit flows.
  - Introduced comprehensive mock utilities to support deterministic, isolated socket testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->